### PR TITLE
server酱微信公众号在4月底停止服务，可以添加新版server酱【企业微信通道推送】方法嘛？

### DIFF
--- a/.github/workflows/work.yaml
+++ b/.github/workflows/work.yaml
@@ -14,6 +14,7 @@ on:
     
 env:
   JD_COOKIE: ${{ secrets.JD_COOKIE }}
+  JD_DUAL_COOKIE: ${{ secrets.JD_DUAL_COOKIE }}
   PUSH_KEY: ${{ secrets.PUSH_KEY }}
   UPLOAD_BESULT_DIR: true
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## 使用用法
 * 点击右上角 `Fork` 项目；
-* `Settings` -> `Secrets` 中添加京东cookie、Server酱SCKEY
+* `Settings` -> `Secrets` 中添加京东cookie、Server酱SCKEY；
 	- `JD_COOKIE`：京东cookie
 	- `PUSH_KEY`：Server酱SCKEY
 * 点击`Star`，任务会自动执行，运行进度和结果可以在`Actions`页面查看；
@@ -20,16 +20,17 @@
 
 ## 获取京东cookie
 
-* 使用项目中的Chrome插件：`JDCookie`
+* 使用项目中的Chrome插件：`JDCookie`；
 * Chrome中拓展程序开启`开发者模式`；
 * 点击`加载已解压的拓展程序`，选择`JDCookie`目录；
 * 登录[领京豆](https://bean.m.jd.com/)；
-* 点击`JDCookie`即可拷贝京东cookie
+* 点击`JDCookie`即可拷贝京东cookie；
 
 ## 获取Server酱SCKEY
 
-* github 授权登录[Server酱](http://sc.ftqq.com/3.version)官网
-* 在`发送消息`拷贝SCKEY
+* github 授权登录[Server酱](http://sc.ftqq.com/3.version)官网；
+* 菜单栏`微信推送`扫描绑定微信；
+* 菜单栏`发送消息`拷贝SCKEY；
 
 
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,18 @@
 * 凌晨4点定时执行
 *  自定义：.github/workflows/work.yaml 编辑
 
-### 注意问题
+## 注意问题
 
-> 问题：[Fork 项目 cron 不执行](https://github.com/ZHDeveloper/JD_Sign_Action/issues/3)
+> **问题一：[项目Fork后定时任务没有执行](https://github.com/ZHDeveloper/JD_Sign_Action/issues/3)**
 > 
-> 1、建议修改README.md提交，以触发定时任务。
->
-> 2、定时任务的时间是UTC时间，跟中国时间有8小时的时差。
+>>1、建议修改README.md提交，以触发定时任务。
+>>
+>>2、定时任务的时间是UTC时间，跟中国时间有8小时的时差。
+> 
+>  **问题二：京东Cookie的有效期**
+> 
+> >就我自己项目中的使用情况而言，一个月有效期。
+
 
 
 ## 使用用法

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@
 
 ## 使用用法
 * 点击右上角 `Fork` 项目；
-* `Settings` -> `Secrets` 中添加京东cookie、Server酱SCKEY；
-	- `JD_COOKIE`：京东cookie
+* `Settings` -> `Secrets` 中添加京东Cookie、Server酱SCKEY；
+	- `JD_COOKIE`：账号1Cookie
+	- `JD_DUAL_COOKIE`：账号2Cookie(选填)
 	- `PUSH_KEY`：Server酱SCKEY
 * 点击`Star`，任务会自动执行，运行进度和结果可以在`Actions`页面查看；
 * 当任务运行完成时，会将运行结果和错误信息打包到`Artifacts`，可自行下载查看；
+* 如果配置了Server酱，运行结果会推送到微信；
 
 ## 获取京东cookie
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@
 * 凌晨4点定时执行
 *  自定义：.github/workflows/work.yaml 编辑
 
+### 注意问题
+
+> 问题：[Fork 项目 cron 不执行](https://github.com/ZHDeveloper/JD_Sign_Action/issues/3)
+> 
+> 1、建议修改README.md提交，以触发定时任务。
+>
+> 2、定时任务的时间是UTC时间，跟中国时间有8小时的时差。
+
+
 ## 使用用法
 * 点击右上角 `Fork` 项目；
 * `Settings` -> `Secrets` 中添加京东Cookie、Server酱SCKEY；

--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@
 * [jerrykuku/luci-app-jd-dailybonus](https://github.com/jerrykuku/luci-app-jd-dailybonus)
 
 ## test
+## test

--- a/README.md
+++ b/README.md
@@ -61,3 +61,5 @@
 * [NobyDa/Script/JD-DailyBonus](https://github.com/NobyDa/Script/blob/master/JD-DailyBonus/JD_DailyBonus.js)
 * [ruicky/jd-sign-bot](https://github.com/ruicky/jd_sign_bot)
 * [jerrykuku/luci-app-jd-dailybonus](https://github.com/jerrykuku/luci-app-jd-dailybonus)
+
+## test

--- a/jd_sign.js
+++ b/jd_sign.js
@@ -56,7 +56,7 @@ function setupCookie() {
   var js_content = fs.readFileSync(js_path, 'utf8')
   js_content = js_content.replace(/var Key = ''/, `var Key = '${cookie}'`)
   if (dual_cookie) {
-    js_content = js_content.replace(/var DualKey = ''/, `var DualKey = '${cookie}'`)
+    js_content = js_content.replace(/var DualKey = ''/, `var DualKey = '${dual_cookie}'`)
   }
   fs.writeFileSync(js_path, js_content, 'utf8')
 }

--- a/jd_sign.js
+++ b/jd_sign.js
@@ -7,8 +7,10 @@ const fs = require('fs')
 const rp = require('request-promise')
 const download = require('download')
 
-// 京东cookie
+// 京东Cookie
 const cookie = process.env.JD_COOKIE
+// 京东Cookie
+const dual_cookie = process.env.JD_DUAL_COOKIE
 // Server酱SCKEY
 const push_key = process.env.PUSH_KEY
 
@@ -41,9 +43,21 @@ Date.prototype.Format = function (fmt) {
   return fmt;
 };
 
+function dateFormat() {
+  var timezone = 8;
+  var GMT_offset = new Date().getTimezoneOffset();
+  var n_Date = new Date().getTime();
+  var t_Date = new Date(n_Date + GMT_offset * 60 * 1000 + timezone * 60 * 60 * 1000);
+  console.log(t_Date)
+  return t_Date.Format('yyyy.MM.dd')
+}
+
 function setupCookie() {
   var js_content = fs.readFileSync(js_path, 'utf8')
   js_content = js_content.replace(/var Key = ''/, `var Key = '${cookie}'`)
+  if (dual_cookie) {
+    js_content = js_content.replace(/var DualKey = ''/, `var DualKey = '${cookie}'`)
+  }
   fs.writeFileSync(js_path, js_content, 'utf8')
 }
 
@@ -57,7 +71,7 @@ function sendNotificationIfNeed() {
     console.log('没有执行结果，任务中断!'); return;
   }
 
-  let text = "京东签到_" + new Date().Format('yyyy.MM.dd');
+  let text = "京东签到_" + dateFormat();
   let desp = fs.readFileSync(result_path, "utf8")
 
   // 去除末尾的换行


### PR DESCRIPTION
因为微信发布公告将在4月底下线模板消息，Server酱开发了以企业微信为主的多通道新版（ Turbo版 sct.ftqq.com ）。旧版将在4月后下线，请尽快完成配置的更新。

配置方式如下：

访问 sct.ftqq.com， 微信扫码登入  
点击「消息通道」，选择「企业微信应用消息」，按页面下方的提示配置企业微信
配置完成后，点击「SendKey」页面，就可以找到新的 SendKey了
在你要调用的地方，用新的 SendKey 替换旧版的 sckey；用 sctapi.ftqq.com 替换旧版请求链接中的 sc.ftqq.com ，（没有地方填请求链接的可以暂时不改）。替换后，消息就会推送到企业微信等你指定的新通道上啦
访问新版( Turbo版 )：sct.ftqq.com
继续访问旧版： sc.ftqq.com 